### PR TITLE
fix: handle empty mosID in acks

### DIFF
--- a/packages/connector/src/__tests__/Profile2.spec.ts
+++ b/packages/connector/src/__tests__/Profile2.spec.ts
@@ -499,6 +499,27 @@ describe('Profile 2', () => {
 		expect(mosTypes.mosString128.stringify(returnedAck.ID)).toEqual('96857485')
 		checkAckSnapshot(returnedAck)
 	})
+	test('sendStoryStatus with missing incoming mosID', async () => {
+		// This test may seem weird, but this has been seen when talking with ENPS for specifically this operation.
+
+		const mockReplyRoAck = jest.fn((data) => {
+			const str = decode(data)
+			const messageID = getMessageId(str)
+			return encode(getXMLReply(messageID, xmlData.roAck, '')) // empty mosID
+		})
+
+		// Prepare server response
+		socketMockUpper.mockAddReply(mockReplyRoAck)
+		const returnedAck: IMOSROAck = await mosDevice.sendStoryStatus(xmlApiData.roElementStat_story)
+		await socketMockUpper.mockWaitForSentMessages()
+		expect(mockReplyRoAck).toHaveBeenCalledTimes(1)
+		const msg = decode(mockReplyRoAck.mock.calls[0][0])
+		expect(msg).toMatch(/<roElementStat element="STORY">/)
+		checkMessageSnapshot(msg)
+		expect(returnedAck).toBeTruthy()
+		expect(mosTypes.mosString128.stringify(returnedAck.ID)).toEqual('96857485')
+		checkAckSnapshot(returnedAck)
+	})
 	test('sendItemStatus', async () => {
 		// Prepare server response
 		socketMockUpper.mockAddReply(mockReplyRoAck)

--- a/packages/connector/src/__tests__/__snapshots__/Profile2.spec.ts.snap
+++ b/packages/connector/src/__tests__/__snapshots__/Profile2.spec.ts.snap
@@ -4626,3 +4626,106 @@ exports[`Profile 2 sendStoryStatus 2`] = `
   "strict": true,
 }
 `;
+
+exports[`Profile 2 sendStoryStatus with missing incoming mosID 1`] = `
+"<mos>
+  <ncsID>their.mos.id</ncsID>
+  <mosID>our.mos.id</mosID>
+  <messageID>xx</messageID>
+  <roElementStat element="STORY">
+    <roID>5PM</roID>
+    <storyID>HOTEL FIRE</storyID>
+    <status>PLAY</status>
+    <time>xx</time>
+  </roElementStat>
+</mos>"
+`;
+
+exports[`Profile 2 sendStoryStatus with missing incoming mosID 2`] = `
+{
+  "ID": {
+    "_mosString128": "96857485",
+  },
+  "Status": {
+    "_mosString128": "Unknown object M000133",
+  },
+  "Stories": [
+    {
+      "ID": {
+        "_mosString128": "5983A501:0049B924:8390EF2B",
+      },
+      "Items": [
+        {
+          "Channel": {
+            "_mosString128": "",
+          },
+          "ID": {
+            "_mosString128": "0",
+          },
+          "Objects": [
+            {
+              "ID": {
+                "_mosString128": "M000224",
+              },
+              "Status": "LOADED",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      "ID": {
+        "_mosString128": "3854737F:0003A34D:983A0B28",
+      },
+      "Items": [
+        {
+          "Channel": {
+            "_mosString128": "",
+          },
+          "ID": {
+            "_mosString128": "0",
+          },
+          "Objects": [
+            {
+              "ID": {
+                "_mosString128": "M000133",
+              },
+              "Status": "UNKNOWN",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  "_messageID": 0,
+  "mosTypes": {
+    "mosDuration": {
+      "create": [Function],
+      "fallback": [Function],
+      "is": [Function],
+      "stringify": [Function],
+      "validate": [Function],
+      "valueOf": [Function],
+    },
+    "mosString128": {
+      "create": [Function],
+      "fallback": [Function],
+      "is": [Function],
+      "stringify": [Function],
+      "validate": [Function],
+      "valueOf": [Function],
+    },
+    "mosTime": {
+      "create": [Function],
+      "fallback": [Function],
+      "is": [Function],
+      "stringify": [Function],
+      "validate": [Function],
+      "valueOf": [Function],
+    },
+    "strict": true,
+  },
+  "port": "upper",
+  "strict": true,
+}
+`;

--- a/packages/connector/src/connection/mosMessageParser.ts
+++ b/packages/connector/src/connection/mosMessageParser.ts
@@ -125,9 +125,9 @@ export class MosMessageParser extends EventEmitter<MosMessageParserEvents> {
 			}
 		} catch (err) {
 			// eslint-disable-next-line no-console
-			console.log('dataChunks-------------\n', this.dataChunks)
+			console.log('dataChunks-------------\n' + this.dataChunks)
 			// eslint-disable-next-line no-console
-			console.log('messageString---------\n', messageString)
+			console.log('messageString---------\n' + messageString)
 			// this.emit('error', e)
 
 			throw err

--- a/packages/helper/src/utils/Utils.ts
+++ b/packages/helper/src/utils/Utils.ts
@@ -167,6 +167,18 @@ export function xml2js(messageString: string): MosModel.AnyXMLObject {
 	}
 	concatChildrenAndTraverseObject(object)
 
+	const convertEmptyObjectToString = (obj: any): any => {
+		if (!!obj && typeof obj === 'object' && Object.keys(obj).length === 0) {
+			return ''
+		} else {
+			return obj
+		}
+	}
+	const mosObject = object.mos as MosModel.AnyXMLObject | undefined
+	if (mosObject?.mosID !== undefined) {
+		mosObject.mosID = convertEmptyObjectToString(mosObject.mosID)
+	}
+
 	return object
 }
 export function addTextElement(


### PR DESCRIPTION


## About the Contributor
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a: Bug fix 

## Current Behavior

In some cases we are seeing an ack from the nrcs which is missing the mosID, causing mos-connection to fail to parse the message and have issues.

This is a quick fix to ignore these errors, and allow the connection to operate as expected. As far as I can tell, we either ignore this value as we are expecting an ack with a matching messageId, or check it against the configured mosID.

Long term maybe this could be removed, once we stop receiving these messages from our NRCS


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
